### PR TITLE
fix: extract password hashing to dedicated service

### DIFF
--- a/authn/di/container.go
+++ b/authn/di/container.go
@@ -41,9 +41,13 @@ func ProvideUserRepository() repository.IUserRepository {
 	return repo
 }
 
+func ProvideHashingService() service.IHashingService {
+	return service.NewHashingService()
+}
+
 func ProvideUserService() service.IUserService {
 
-	return service.NewUserService(ProvideUserRepository())
+	return service.NewUserService(ProvideUserRepository(), ProvideHashingService())
 }
 
 func ProvideAuthnService() handlers.IAuthnService {

--- a/authn/service/encryption_service.go
+++ b/authn/service/encryption_service.go
@@ -6,3 +6,7 @@ type EncryptionService interface {
 	Encrypt(ctx context.Context, textToEncrypt string) (string, error)
 	Decrypt(ctx context.Context, encryptedText string) (string, error)
 }
+
+type IHashingService interface {
+	HashPassword(ctx context.Context, password string) (string, error)
+}

--- a/authn/service/hashing_service.go
+++ b/authn/service/hashing_service.go
@@ -1,0 +1,21 @@
+package service
+
+import (
+	"context"
+
+	"golang.org/x/crypto/bcrypt"
+)
+
+type HashingService struct{}
+
+func NewHashingService() IHashingService {
+	return &HashingService{}
+}
+
+func (s *HashingService) HashPassword(ctx context.Context, password string) (string, error) {
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.DefaultCost)
+	if err != nil {
+		return "", err
+	}
+	return string(hash), nil
+}


### PR DESCRIPTION
- Create IHashingService interface with HashingService implementation
- Move bcrypt password hashing from UserServiceImpl to HashingService
- Update DI container to inject IHashingService dependency
- Rename encryption_service.go to only contain IEncryptionService interface

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured password hashing into a dedicated service component, improving separation of concerns within the authentication system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->